### PR TITLE
PN-2361 fix eventId più lungo di 80 caratteri

### DIFF
--- a/src/main/java/it/pagopa/pn/externalchannels/schedule/MessageScheduler.java
+++ b/src/main/java/it/pagopa/pn/externalchannels/schedule/MessageScheduler.java
@@ -113,7 +113,7 @@ public class MessageScheduler {
         if (EventMessageUtil.LEGAL_CHANNELS.contains(channel)) {
             enrichWithLocation(eventMessage, iun);
         }
-        PnDeliveryPushEvent pnDeliveryPushEvent = EventMessageUtil.buildDeliveryPushEvent(eventMessage, iun, requestId);
+        PnDeliveryPushEvent pnDeliveryPushEvent = EventMessageUtil.buildDeliveryPushEvent(eventMessage, iun);
         log.info("[{}] Message to send: {}", iun, pnDeliveryPushEvent);
         deliveryPushSendClient.sendNotification(pnDeliveryPushEvent);
         log.debug("[{}] Message sent", iun);

--- a/src/main/java/it/pagopa/pn/externalchannels/util/EventMessageUtil.java
+++ b/src/main/java/it/pagopa/pn/externalchannels/util/EventMessageUtil.java
@@ -81,11 +81,11 @@ public class EventMessageUtil {
         return ProgressEventCategory.PROGRESS;
     }
 
-    public static PnDeliveryPushEvent buildDeliveryPushEvent(SingleStatusUpdate event, String iun, String requestId) {
+    public static PnDeliveryPushEvent buildDeliveryPushEvent(SingleStatusUpdate event, String iun) {
         return PnDeliveryPushEvent.builder()
                 .header(StandardEventHeader.builder()
                         .iun(iun)
-                        .eventId(requestId)
+                        .eventId("mock-" + UUID.randomUUID())
                         .eventType("EXTERNAL_CHANNELS_EVENT")
                         .publisher(EventPublisher.EXTERNAL_CHANNELS.name())
                         .createdAt(Instant.now())


### PR DESCRIPTION
L'errore trovato è il seguente: A batch entry id can only contain alphanumeric characters, hyphens and underscores. It can be at most 80 letters long. 