### PR TITLE
attachmentid

### DIFF
--- a/src/main/java/it/pagopa/pn/externalchannels/mapper/PaperProgressStatusEventToConsolidatorePaperProgressStatusEvent.java
+++ b/src/main/java/it/pagopa/pn/externalchannels/mapper/PaperProgressStatusEventToConsolidatorePaperProgressStatusEvent.java
@@ -19,11 +19,12 @@ public class PaperProgressStatusEventToConsolidatorePaperProgressStatusEvent {
         if (input.getAttachments() != null)
         {
             List<PaperProgressStatusEventAttachments> attachments = new ArrayList<>();
+            int docId = 0;
             for (AttachmentDetails detail: input.getAttachments()) {
                 PaperProgressStatusEventAttachments paperProgressStatusEventAttachments = new PaperProgressStatusEventAttachments();
                 paperProgressStatusEventAttachments.setDate(detail.getDate().toInstant());
                 paperProgressStatusEventAttachments.setDocumentType(detail.getDocumentType());
-                paperProgressStatusEventAttachments.setId(detail.getId());
+                paperProgressStatusEventAttachments.setId(Integer.toString(docId++));
                 paperProgressStatusEventAttachments.setUri(detail.getUrl());
                 paperProgressStatusEventAttachments.setSha256(detail.getId().split("\\|")[1]);
                 attachments.add(paperProgressStatusEventAttachments);

--- a/src/main/java/it/pagopa/pn/externalchannels/util/EventMessageUtil.java
+++ b/src/main/java/it/pagopa/pn/externalchannels/util/EventMessageUtil.java
@@ -248,7 +248,7 @@ public class EventMessageUtil {
         Optional<List<String>> eventCodeList = eventCodeDocumentsDao.consumeByKey(eventCodeMapKey);
         log.info("Event code  {} result list {}",eventCodeMapKey,eventCodeList);
         if(eventCodeList.isPresent()) {
-            int id = 1;
+            int id = 0;
             for(String documentType: eventCodeList.get()){
                 eventMessage.getAnalogMail().addAttachmentsItem(buildAttachment(iun, id++, documentType, delaydoc, safeStorageService));
             }
@@ -271,7 +271,7 @@ public class EventMessageUtil {
             log.info("[{}] Message sent to Safe Storage", iun);
             return new AttachmentDetails()
                     .url(SAFE_STORAGE_URL_PREFIX + response.getKey())
-                    .id(iun + "DOCMock_"+id + "|" + response.getSha256())
+                    .id(id)
                     .documentType(documentType)
                     .date(OffsetDateTime.now().minus(delaydoc));
         } catch (IOException e) {

--- a/src/main/java/it/pagopa/pn/externalchannels/util/EventMessageUtil.java
+++ b/src/main/java/it/pagopa/pn/externalchannels/util/EventMessageUtil.java
@@ -248,7 +248,7 @@ public class EventMessageUtil {
         Optional<List<String>> eventCodeList = eventCodeDocumentsDao.consumeByKey(eventCodeMapKey);
         log.info("Event code  {} result list {}",eventCodeMapKey,eventCodeList);
         if(eventCodeList.isPresent()) {
-            int id = 0;
+            int id = 1;
             for(String documentType: eventCodeList.get()){
                 eventMessage.getAnalogMail().addAttachmentsItem(buildAttachment(iun, id++, documentType, delaydoc, safeStorageService));
             }
@@ -271,7 +271,7 @@ public class EventMessageUtil {
             log.info("[{}] Message sent to Safe Storage", iun);
             return new AttachmentDetails()
                     .url(SAFE_STORAGE_URL_PREFIX + response.getKey())
-                    .id(id)
+                    .id(iun + "DOCMock_"+id + "|" + response.getSha256())
                     .documentType(documentType)
                     .date(OffsetDateTime.now().minus(delaydoc));
         } catch (IOException e) {


### PR DESCRIPTION
```"analogMail": {
            "requestId": "FFMANTEST.IUN_FATI-TMAN-20230330-1434-R-1.RECINDEX_0.PCRETRY_0",
            "registeredLetterCode": null,
            "productType": "AR",
            "iun": "FATI-TMAN-20230330-1434-R-1",
            "statusCode": "RECRN001B",
            "statusDescription": "Mock status",
            "statusDateTime": "1680186894.0022597",
            "deliveryFailureCause": null,
            "attachments": [
                {
                    "uri": "safestorage://PN_EXTERNAL_LEGAL_FACTS-0003-WVUS-3AHD-2NRP-CRXL",
                    "id": "FATI-TMAN-20230330-1434-R-1DOCMock_1|UaMdYj7cAVO6EZTC9ddUBD7pbkG6zdEZ0LaL/3cmphU=",
                    "documentType": "AR",
                    "documentId": null,
                    "sha256": "UaMdYj7cAVO6EZTC9ddUBD7pbkG6zdEZ0LaL/3cmphU=",
                    "date": "1680186896.1097248"
                }
            ],
            "discoveredAddress": null,
            "clientRequestTimeStamp": "1680186895.0022466"
        }
```

L'id del documento deve essere una stringa con un numero progressivo